### PR TITLE
Fix reliability issues in Dynamic DNS updater

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 CLOUDFLARE_API_TOKEN=your-api-token-here
-ZONE_ID=your-zone-id
-DNS_RECORD_NAMES=subdomain.example.com,subdomain2.example.com  # Records to update
+CLOUDFLARE_ZONEID=your-zone-id
+CLOUDFLARE_DOMAIN_LIST=subdomain.example.com,subdomain2.example.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 utils/config.py
 saved_ip.txt
+saved_ip.txt.tmp
 .env
 uv.lock
 pyproject.toml

--- a/main.py
+++ b/main.py
@@ -1,8 +1,16 @@
 import os
 import logging
+import signal
 import time
 import requests
 from dotenv import load_dotenv
+from tenacity import (
+    retry,
+    stop_after_attempt,
+    wait_exponential,
+    retry_if_exception,
+    retry_if_exception_type,
+)
 from utils.logging_config import setup_logging
 
 setup_logging()
@@ -10,62 +18,125 @@ logger = logging.getLogger()
 load_dotenv()
 
 BASE_URL = "https://api.cloudflare.com/client/v4/zones/"
+REQUEST_TIMEOUT = 15
+IP_SOURCES = [
+    "https://api.ipify.org?format=json",
+    "https://api64.ipify.org?format=json",
+    "https://ifconfig.me/ip",
+]
+
 CLOUDFLARE_ZONEID = os.getenv("CLOUDFLARE_ZONEID")
 CLOUDFLARE_API_TOKEN = os.getenv("CLOUDFLARE_API_TOKEN")
-CLOUDFLARE_DOMAIN_LIST = [d.strip() for d in os.getenv("CLOUDFLARE_DOMAIN_LIST", "").split(',') if d.strip()]
+CLOUDFLARE_DOMAIN_LIST = [
+    d.strip() for d in os.getenv("CLOUDFLARE_DOMAIN_LIST", "").split(",") if d.strip()
+]
+UPDATE_INTERVAL_MINUTES = int(os.getenv("UPDATE_INTERVAL_MINUTES", "10"))
+FAILURE_BACKOFF_MAX_MINUTES = int(os.getenv("FAILURE_BACKOFF_MAX_MINUTES", "30"))
+FAILURE_COUNT_BEFORE_BACKOFF = int(os.getenv("FAILURE_COUNT_BEFORE_BACKOFF", "5"))
 
 if not CLOUDFLARE_ZONEID or not CLOUDFLARE_API_TOKEN or not CLOUDFLARE_DOMAIN_LIST:
     logger.critical("Missing required environment variables. Check .env file.")
     exit(1)
 
+_shutdown_requested = False
 
 
-def get_public_ip():
-    try:
-        logger.debug('Fetching public IP')
-        result = requests.get("https://api.ipify.org?format=json")
-        result.raise_for_status()
-        return result.json()['ip']
-    except Exception as e:
-        logger.error(f'Failed to fetch public IP: {e}')
+def _shutdown_handler(signum=None, frame=None):
+    global _shutdown_requested
+    _shutdown_requested = True
 
 
-def save_ip(ip):
-    with open("saved_ip.txt", "w") as f:
+signal.signal(signal.SIGTERM, _shutdown_handler)
+
+
+def _parse_ip_from_response(response, url):
+    if "ifconfig.me" in url:
+        ip = response.text.strip()
+    else:
+        data = response.json()
+        ip = data.get("ip") if isinstance(data, dict) else None
+    if not ip or not ip.replace(".", "").isdigit():
+        raise ValueError(f"Invalid IP from {url}: {ip}")
+    return ip
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=2, min=2, max=8),
+    retry=retry_if_exception_type((requests.RequestException, ValueError)),
+    reraise=True,
+)
+def get_public_ip() -> str:
+    last_error = None
+    for url in IP_SOURCES:
+        try:
+            logger.debug("Fetching public IP from %s", url)
+            response = requests.get(url, timeout=REQUEST_TIMEOUT)
+            response.raise_for_status()
+            ip = _parse_ip_from_response(response, url)
+            return ip
+        except (requests.RequestException, ValueError) as e:
+            last_error = e
+            logger.warning("IP source %s failed: %s", url, e)
+            continue
+    raise last_error
+
+
+def save_ip(ip: str) -> None:
+    tmp_path = "saved_ip.txt.tmp"
+    target_path = "saved_ip.txt"
+    with open(tmp_path, "w") as f:
         f.write(ip)
+    os.replace(tmp_path, target_path)
 
 
-def get_saved_ip():
+def get_saved_ip() -> str | None:
     if os.path.exists("saved_ip.txt"):
         with open("saved_ip.txt", "r") as f:
             return f.read().strip()
     return None
 
 
-def get_cloudflare_record_id(domain_name):
+def _api_headers():
+    return {
+        "Authorization": f"Bearer {CLOUDFLARE_API_TOKEN}",
+        "Content-Type": "application/json",
+    }
+
+
+def _retry_on_5xx_or_timeout(exc):
+    if isinstance(exc, requests.HTTPError):
+        resp = getattr(exc, "response", None)
+        if resp is not None and 400 <= resp.status_code < 500:
+            return False
+    return isinstance(exc, requests.RequestException)
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=2, min=2, max=8),
+    retry=retry_if_exception(_retry_on_5xx_or_timeout),
+    reraise=True,
+)
+def get_cloudflare_record_id(domain_name: str) -> str:
     url = f"{BASE_URL}{CLOUDFLARE_ZONEID}/dns_records"
-    headers = {
-        "Authorization": f"Bearer {CLOUDFLARE_API_TOKEN}",
-        "Content-Type": "application/json",
-    }
-    try:
-        response = requests.get(url, headers=headers)
-        response.raise_for_status()
-        records = response.json().get("result", [])
-        for record in records:
-            if record["name"] == domain_name:
-                return record["id"]
-        raise ValueError(f"DNS record with name '{domain_name}' not found.")
-    except requests.RequestException as e:
-        logger.error(f"Failed to fetch DNS records: {e}")
+    response = requests.get(url, headers=_api_headers(), timeout=REQUEST_TIMEOUT)
+    response.raise_for_status()
+    records = response.json().get("result", [])
+    for record in records:
+        if record["name"] == domain_name:
+            return record["id"]
+    raise ValueError(f"DNS record with name '{domain_name}' not found.")
 
 
-def update_cloudflare_domain(new_ip, record_id, domain_name):
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=2, min=2, max=8),
+    retry=retry_if_exception(_retry_on_5xx_or_timeout),
+    reraise=True,
+)
+def update_cloudflare_domain(new_ip: str, record_id: str, domain_name: str) -> None:
     url = f"{BASE_URL}{CLOUDFLARE_ZONEID}/dns_records/{record_id}"
-    headers = {
-        "Authorization": f"Bearer {CLOUDFLARE_API_TOKEN}",
-        "Content-Type": "application/json",
-    }
     data = {
         "type": "A",
         "name": domain_name,
@@ -73,26 +144,80 @@ def update_cloudflare_domain(new_ip, record_id, domain_name):
         "ttl": 1,
         "proxied": False,
     }
-    try:
-        response = requests.put(url, json=data, headers=headers)
-        response.raise_for_status()
-        logger.info(f"Updated '{domain_name}' to {new_ip}.")
-    except requests.RequestException as e:
-        logger.error(f"Error updating DNS record for {domain_name}: {e}")
+    response = requests.put(
+        url, json=data, headers=_api_headers(), timeout=REQUEST_TIMEOUT
+    )
+    response.raise_for_status()
+    logger.info("Updated '%s' to %s.", domain_name, new_ip)
+
+
+def validate_startup() -> None:
+    url = f"{BASE_URL}{CLOUDFLARE_ZONEID}"
+    response = requests.get(url, headers=_api_headers(), timeout=REQUEST_TIMEOUT)
+    response.raise_for_status()
+    if not response.json().get("success"):
+        raise RuntimeError("Cloudflare API returned success=false")
+    for domain in CLOUDFLARE_DOMAIN_LIST:
+        get_cloudflare_record_id(domain)
+    logger.info("Startup validation passed.")
 
 
 if __name__ == "__main__":
-    while True:
+    try:
+        validate_startup()
+    except Exception as e:
+        logger.critical("Startup validation failed: %s", e)
+        exit(1)
+
+    failure_count = 0
+
+    while not _shutdown_requested:
         try:
             current_ip = get_public_ip()
             if current_ip != get_saved_ip():
-                logger.info(f"New IP detected: {current_ip}")
+                logger.info("New IP detected: %s", current_ip)
+                record_ids = {}
                 for domain_name in CLOUDFLARE_DOMAIN_LIST:
-                    record_id = get_cloudflare_record_id(domain_name)
-                    update_cloudflare_domain(current_ip, record_id, domain_name)
+                    record_ids[domain_name] = get_cloudflare_record_id(domain_name)
+                for domain_name in CLOUDFLARE_DOMAIN_LIST:
+                    update_cloudflare_domain(
+                        current_ip, record_ids[domain_name], domain_name
+                    )
                 save_ip(current_ip)
+                failure_count = 0
             else:
                 logger.debug("IP has not changed. No update needed.")
+                failure_count = 0
+        except KeyboardInterrupt:
+            logger.info("Shutdown requested.")
+            break
         except Exception as e:
-            logger.error(f"Unhandled error: {e}")
-        time.sleep(60 * 10)
+            failure_count += 1
+            logger.error("Unhandled error: %s", e)
+            sleep_minutes = (
+                UPDATE_INTERVAL_MINUTES
+                if failure_count < FAILURE_COUNT_BEFORE_BACKOFF
+                else min(
+                    UPDATE_INTERVAL_MINUTES
+                    * (
+                        2
+                        ** min(
+                            max(0, failure_count - FAILURE_COUNT_BEFORE_BACKOFF), 3
+                        )
+                    ),
+                    FAILURE_BACKOFF_MAX_MINUTES,
+                )
+            )
+            if failure_count >= FAILURE_COUNT_BEFORE_BACKOFF:
+                logger.warning(
+                    "Failure %d; backing off to %d min sleep.",
+                    failure_count,
+                    sleep_minutes,
+                )
+            time.sleep(60 * sleep_minutes)
+            continue
+
+        for _ in range(60 * UPDATE_INTERVAL_MINUTES):
+            if _shutdown_requested:
+                break
+            time.sleep(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.28.0
 python-dotenv>=1.0.0
+tenacity>=8.0.0


### PR DESCRIPTION
## Summary
Implements all reliability improvements identified in the issue tracker.

## Changes

| Issue | Fix |
|-------|-----|
| #1 | Align .env.example with code variable names |
| #2 | Configurable polling (UPDATE_INTERVAL_MINUTES) and failure backoff |
| #3 | Startup validation for API token and domains |
| #4 | Strict error handling: raise on failure instead of returning None |
| #5 | Retry logic with exponential backoff (tenacity), no retry on 4xx |
| #6 | Atomic save_ip via temp file + os.replace |
| #7 | All-or-nothing domain updates (fetch all IDs first, save_ip only after all succeed) |
| #8 | Graceful shutdown: SIGTERM handler, explicit KeyboardInterrupt |
| #9 | Multiple IP sources (ipify, api64.ipify, ifconfig.me) |
| #10 | 15s timeout on all HTTP requests |

## New env vars (optional)
- `UPDATE_INTERVAL_MINUTES` (default: 10)
- `FAILURE_BACKOFF_MAX_MINUTES` (default: 30)
- `FAILURE_COUNT_BEFORE_BACKOFF` (default: 5)

## Dependencies
Added `tenacity>=8.0.0` for retry logic.

Closes #1, Closes #2, Closes #3, Closes #4, Closes #5, Closes #6, Closes #7, Closes #8, Closes #9, Closes #10